### PR TITLE
docs: どこにクライアントコンポーネントを作成するかわかるようにしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ RSCでは、状態を保持したり、イベントハンドラ等のインタ�
 
 このような処理は**クライアントコンポーネント**を作成し、分離します。
 
-`TodoCreationform.tsx`
+`components/TodoCreationForm.tsx`
 
 ```tsx
 "use client"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # Use root/example as user/password credentials
-version: "3.1"
 
 services:
   db:


### PR DESCRIPTION
Next.js も初めて触ったため、クライアントコンポーネントをどこに作るのか悩んだので、ファイル名にパスを含めて記載しても良いのではないかと思いました。
